### PR TITLE
web3 version issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ethereumjs-tx": "^1.3.7",
     "ethereumjs-util": "^6.0.0",
     "meta-web3": "^0.3.3",
-    "metasdk-react": "^0.5.4",
+    "metasdk-react": "^0.6.1",
     "node-fetch": "^2.3.0",
     "react": "^16.8.3",
     "react-collapsible": "^2.3.2",
@@ -16,7 +16,7 @@
     "react-loading": "^2.0.3",
     "react-router": "^4.3.1",
     "underscore": "^1.9.1",
-    "web3": "1.0.0-beta.34"
+    "web3": "1.7.3"
   },
   "scripts": {
     "start": "PORT=3005 react-app-rewired start",


### PR DESCRIPTION
문제:
web3 버전 이슈로 패키지 설치가 되지 않습니다.

해결 방안:
metasdk-react: ^0.5.4 -> ^0.6.1
web3 -> 1.0.0-beta.34 -> 1.7.3