### PR TITLE
:sparkles: change how authority lists are imported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
+# npm package
 node_modules/
-build/
+package-lock.json
 
+# build variables
+build/
+# env files
 .env.*
 
-package-lock.json
+# static json files
+src/static/

--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,8 @@ import getWeb3Instance, { web3Instance } from "./web3";
 import { constants, ENV_NAMES_SHA3 } from "./constants";
 import * as util from "./util";
 
+import AuthorityList from "./static/AuthorityList.json";
+
 import "./App.css";
 import "./components/style/style.css";
 
@@ -68,7 +70,6 @@ class App extends React.Component {
     super(props);
     this.initContractData = this.initContractData.bind(this);
     this.refreshContractData = this.refreshContractData.bind(this);
-
     // get web3 instance
     getWeb3Instance().then(
       async (web3Config) => {
@@ -257,15 +258,8 @@ class App extends React.Component {
 
   // get a static list for network status from github repository
   async initAuthorityData() {
-    let authorityOriginData = await util.getAuthorityLists(
-      constants.authorityRepo.org,
-      constants.authorityRepo.repo,
-      constants.authorityRepo.branch,
-      constants.authorityRepo.source
-    );
-    this.data.authorityOriginData = await this.refineAuthority(
-      authorityOriginData
-    );
+    const authorityList = AuthorityList[process.env.NODE_ENV] || [];
+    this.data.authorityOriginData = await this.refineAuthority(authorityList);
     util.setAuthorityToLocal(this.data.authorityOriginData);
   }
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,5 @@
 import { web3Instance } from "./web3";
 
-const fetch = require("node-fetch");
 const secondsInDay = 86400;
 
 // ---------- time ---------- //
@@ -223,12 +222,6 @@ export const checkMemberStakingAmount = (min, max) => {
 export const shouldPass = () => {
   // eslint-disable-next-line
   throw "Function should be passed";
-};
-
-// get authority list with static file
-export const getAuthorityLists = (org, repo, branch, source) => {
-  const URL = `https://raw.githubusercontent.com/${org}/${repo}/${branch}/${source}`;
-  return fetch(URL).then((response) => response.json());
 };
 
 // serialize and deserialize object at local storage


### PR DESCRIPTION
수정 사항
- `METADIUM/meta-governance-dapp` 의 경우 authority list 를 `meta-authorities` 라는 repository 에서 관리했는데,
이렇게 관리할 경우 authority list 가 변경될 때 마다 해당 repository 에서 직접 변경해야 하는 번거로움이 있어 한 프로젝트에서 관리하고자 한다.

참고
- Confluence 에 관련 글 올려두었으니 참고 부탁드립니다.