### PR TITLE
Hotfix/authority

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -216,13 +216,13 @@ class App extends React.Component {
   // or initalize new authority list
   async getAuthorityData() {
     const modifiedBlock = await contracts.governance.getModifiedBlock();
-    if (
-      modifiedBlock === util.getModifiedFromLocal() &&
-      util.getAuthorityFromLocal()
-    ) {
-      this.data.authorityOriginData = util.getAuthorityFromLocal();
-      return;
-    }
+    // if (
+    //   modifiedBlock === util.getModifiedFromLocal() &&
+    //   util.getAuthorityFromLocal()
+    // ) {
+    //   this.data.authorityOriginData = util.getAuthorityFromLocal();
+    //   return;
+    // }
     await this.initAuthorityData();
     util.setModifiedToLocal(modifiedBlock);
   }

--- a/src/components/Authority.js
+++ b/src/components/Authority.js
@@ -58,11 +58,11 @@ class Authority extends React.Component {
   onReadMoreClick = (index) => {
     const element = this.descriptions[index];
     const btn = this.readMoreBtns[index];
-    if (element.offsetHeight === constants.authoritieDescriptionHeight) {
-      element.style.height = "auto";
+    if (element.style.maxHeight !== "none") {
+      element.style.maxHeight = "none";
       btn.innerHTML = "- Read Less";
     } else {
-      element.style.height = constants.authoritieDescriptionHeightToPixel;
+      element.style.maxHeight = constants.authoritieDescriptionHeightToPixel;
       btn.innerHTML = "+ Read More";
     }
   };
@@ -112,10 +112,11 @@ class Authority extends React.Component {
       let readMoreBtn = this.readMoreBtns[index];
 
       if (!readMoreBtn || !readMoreBtn.style) {
-        // Cannot modify style
       } else if (
         description.scrollHeight > constants.authoritieDescriptionHeight
       ) {
+        description.style.maxHeight =
+          constants.authoritieDescriptionHeightToPixel;
         readMoreBtn.style.display = "block";
       } else {
         readMoreBtn.style.display = "none";

--- a/src/components/style/style.css
+++ b/src/components/style/style.css
@@ -295,7 +295,7 @@
 .authorityComp .authorityComp_contnet .img_container {
   width: 192px;
   height: 192px;
-  margin-right: 16px;
+  margin: auto 16px auto auto;
   overflow: hidden;
 }
 


### PR DESCRIPTION
수정 사항
- authority list `localStorage` 에서 가져오는 부분 주석 처리
(기획 쪽에서 해당 부분 업데이트가 되면 `localStorage` 를 삭제하고 다시 reload 하는 게 불편하다는 의견이 있어 반영)
- authority list `Read More` 버튼 기능 동작하도록 수정
- logo 이미지 변경으로 인한 margin 값 변경